### PR TITLE
Fix validate command exit status

### DIFF
--- a/internal/application/interactor/model/validate.go
+++ b/internal/application/interactor/model/validate.go
@@ -33,5 +33,9 @@ func (i *ModelValidateInteractor) Validate(modelPath string) error {
 
 	i.output.ModelValidated(modelPath, indexErr, dataErr)
 
-	return nil
+	if indexErr != nil {
+		return indexErr
+	}
+
+	return dataErr
 }

--- a/internal/application/interactor/model/validate_test.go
+++ b/internal/application/interactor/model/validate_test.go
@@ -43,7 +43,7 @@ func TestValidate_IndexError(t *testing.T) {
 
 	err := interactor.Validate(modelPath)
 
-	assert.NoError(t, err)
+	assert.EqualError(t, err, indexErr.Error())
 	mockSvc.AssertExpectations(t)
 	mockOutput.AssertExpectations(t)
 }
@@ -63,7 +63,7 @@ func TestValidate_DataError(t *testing.T) {
 
 	err := interactor.Validate(modelPath)
 
-	assert.NoError(t, err)
+	assert.EqualError(t, err, dataErr.Error())
 	mockSvc.AssertExpectations(t)
 	mockOutput.AssertExpectations(t)
 }


### PR DESCRIPTION
- Return validation errors from the model validation interactor.
- Update the validate tests to cover failing metadata and content checks.
